### PR TITLE
cupcake theme fix Extra Func, added fairyfloss theme

### DIFF
--- a/pyradio/themes/cupcake_by_edunfelt.pyradio-theme
+++ b/pyradio/themes/cupcake_by_edunfelt.pyradio-theme
@@ -22,7 +22,7 @@ Edit Cursor         #fbf1f2 #bfb9c6
 # Text color for extra function indication
 # and jump numbers within the status bar
 # (background color will come from Stations)
-Extra Func          #a3b367
+Extra Func          #69a9a7
 
 # Text color for URL
 # (background color will come from Stations)

--- a/pyradio/themes/fairyfloss.pyradio-theme
+++ b/pyradio/themes/fairyfloss.pyradio-theme
@@ -1,0 +1,34 @@
+# Main foreground and background
+Stations            #f8f8f0 #5a5475
+
+# Playing station text color
+# (background color will come from Stations)
+Active Station      #ffb8d1
+
+# Status bar foreground and background
+Status Bar          #f8f8f0 #343145
+
+# Normal cursor foreground and background
+Normal Cursor       #f8f8f0 #6a6483
+
+# Cursor foreground and background
+# when cursor on playing station
+Active Cursor       #5a5475 #a0a0c0
+
+# Cursor foreground and background
+# This is the Line Editor cursor
+Edit Cursor         #5a5475 #9673d3
+
+# Text color for extra function indication
+# and jump numbers within the status bar
+# (background color will come from Stations)
+Extra Func          #8295d6
+
+# Text color for URL
+# (background color will come from Stations)
+PyRadio URL         #b8a2ce
+
+# Message window borser foreground
+# (background color will come from Stations)
+Messages Border     #9673d3
+


### PR DESCRIPTION
Hi @s-n-g!

Following up on #159, and your [suggestion](https://github.com/coderholic/pyradio/issues/159#issuecomment-1150899090), I have made some small changes to the pink/cupcake theme:

1. changed the name to cupcake (this is the original base16 name),
2. new `Extra Func` color.

Further, I also took the liberty to add a suggested version of the wonderful [Fairyfloss theme](https://sailorhg.github.io/fairyfloss/), if you don't mind it of course!

![fairyfloss](https://user-images.githubusercontent.com/29271899/173401938-bcb23f72-f6f2-41b3-9f42-56777f39dde5.png)
